### PR TITLE
added the ability to support more than one zookeeper instance on the …

### DIFF
--- a/zk-collectd.conf
+++ b/zk-collectd.conf
@@ -9,5 +9,12 @@
 
     <Module "zk-collectd">
         Hosts "localhost"
+        Port 2181
+        Instance "int"
+    </Module>
+    <Module "zk-collectd">
+        Hosts "localhost"
+        Port 2182
+        Instance "qa"
     </Module>
 </Plugin>

--- a/zk-collectd.conf
+++ b/zk-collectd.conf
@@ -9,5 +9,12 @@
 
     <Module "zk-collectd">
         Hosts "localhost"
+        Port 2181
+        Postfix "-int"
+    </Module>
+    <Module "zk-collectd">
+        Hosts "localhost"
+        Port 2182
+        Postfix "-qa"
     </Module>
 </Plugin>

--- a/zk-collectd.conf
+++ b/zk-collectd.conf
@@ -10,11 +10,11 @@
     <Module "zk-collectd">
         Hosts "localhost"
         Port 2181
-        Postfix "-int"
+        Instance "int"
     </Module>
     <Module "zk-collectd">
         Hosts "localhost"
         Port 2182
-        Postfix "-qa"
+        Instance "qa"
     </Module>
 </Plugin>

--- a/zk-collectd.py
+++ b/zk-collectd.py
@@ -33,7 +33,7 @@ from StringIO import StringIO
 
 CONFIGS = []
 
-ZK_HOSTS = ["192.168.10.2"]
+ZK_HOSTS = ["localhost"]
 ZK_PORT = 2181
 ZK_INSTANCE = ""
 COUNTERS = ["zk_packets_received", "zk_packets_sent"]
@@ -133,7 +133,7 @@ def configure_callback(conf):
     zk_instance = ZK_INSTANCE
     for node in conf.children:
         if node.key == 'Hosts':
-            zk_hosts = node.values[0].split(',')
+            zk_hosts = [host.strip() for host in node.values[0].split(',')]
         elif node.key == 'Port':
             zk_port = node.values[0]
         elif node.key == 'Instance':

--- a/zk-collectd.py
+++ b/zk-collectd.py
@@ -133,11 +133,20 @@ def configure_callback(conf):
     zk_instance = ZK_INSTANCE
     for node in conf.children:
         if node.key == 'Hosts':
-            zk_hosts = [host.strip() for host in node.values[0].split(',')]
+            if len(node.values[0]) > 0:
+                zk_hosts = [host.strip() for host in node.values[0].split(',')]
+            else:
+                log("ERROR: Invalid Hosts string. Using default of %s" % zk_hosts)
         elif node.key == 'Port':
-            zk_port = node.values[0]
+            if isinstance(node.values[0], float) and node.values[0] > 0 :
+                zk_port = node.values[0]
+            else:
+                log("ERROR: Invalid Port number. Using default of %s" % zk_port)
         elif node.key == 'Instance':
-            zk_instance = node.values[0]
+            if len(node.values[0]) > 0:
+                zk_instance = node.values[0]
+            else:
+                log("ERROR: Invalid Instance string. Using default of %s" % zk_instance)
         else:
             collectd.warning('zookeeper plugin: Unknown config key: %s.'
                              % node.key)


### PR DESCRIPTION
…same server.

We have ZK integration, QA and PreProd on the same server, but using different ports. So I modified this to allow connecting to multiple instances of ZK on the same server. I also added a prefix to the end of the name sent to collectd so you know which environment it belongs in. 
