### PR TITLE
Add new gauge.zk_is_leader metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ All metrics are reported with the `plugin:zookeeper` dimension. Additionally,
 if you specify an `Instance` in your `Module` configuration block, its value
 will be reported as the `plugin_instance` dimension.
 
+zk_is_leader is a synthetic metric which is 0 iff the contents of zk_server_state is 'follower'
+
 # License
 
 Available under the terms of the Apache Software License v2. See LICENSE

--- a/zk-collectd.py
+++ b/zk-collectd.py
@@ -70,7 +70,9 @@ class ZooKeeperServer(object):
         for line in h.readlines():
             try:
                 key, value = self._parse_line(line)
-                if key not in ['zk_server_state', 'zk_version']:
+                if key == 'zk_server_state':
+                    result['zk_is_leader'] = int(value != 'follower')
+                elif key not in ['zk_version']:
                     result[key] = value
             except ValueError:
                 # Ignore broken lines.


### PR DESCRIPTION
This metric will have a value of 1 if the server is a 'leader' of the cluster,
0 otherwise
