### PR TITLE
declare stats variable

### DIFF
--- a/zk-collectd.py
+++ b/zk-collectd.py
@@ -99,6 +99,7 @@ class ZooKeeperServer(object):
 
 def read_callback():
     """Get stats for all the servers in the cluster."""
+    stats = None
     for conf in CONFIGS:
         for host in conf['hosts']:
             try:


### PR DESCRIPTION
Without this change, when running using system python on a RHEL6 box I got this error in the logs:

Nov  3 17:12:14 bowser01 collectd[26825]: Unhandled python exception in read callback: UnboundLocalError: local variable 'stats' referenced before assignment
Nov  3 17:12:14 myhost collectd[26825]: tcpconns plugin: Reading from netlink succeeded. Will use the netlink method from now on.
Nov  3 17:12:14 myhost collectd[26825]: Traceback (most recent call last):
Nov  3 17:12:14 myhost collectd[26825]:   File "/usr/share/collectd/python/zookeeper.py", line 127, in read_callback#012    return stats
Nov  3 17:12:14 myhost collectd[26825]: UnboundLocalError: local variable 'stats' referenced before assignment
Nov  3 17:12:14 myhost collectd[26825]: read-function of plugin `python.zookeeper' failed. Will suspend it for 60.000 seconds.
