### PR TITLE
Update zk_service_health metric when not serving.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@ All metrics are reported with the `plugin:zookeeper` dimension. Additionally,
 if you specify an `Instance` in your `Module` configuration block, its value
 will be reported as the `plugin_instance` dimension.
 
-zk_is_leader is a synthetic metric which is 0 iff the contents of zk_server_state is 'follower'
+zk_is_leader is a synthetic metric which is 0 if the contents of zk_server_state is 'follower'.
+zk_service_health is a synthetic metric which tracks if service is running and servicing requests.
 
 # License
 


### PR DESCRIPTION
I discovered this issue when testing, I was planning on alerting off zk_service_health metric then noticed it still reported healthy when I forced a loss of quorum. 

Here's the two relevant code snippets which demonstrate the issue with relying on solely using ruok status for service health -

https://github.com/apache/zookeeper/blob/f588e1982f382a586fea53a1fbb11914d48560de/src/java/main/org/apache/zookeeper/server/command/MonitorCommand.java#L39

https://github.com/apache/zookeeper/blob/f588e1982f382a586fea53a1fbb11914d48560de/src/java/main/org/apache/zookeeper/server/command/RuokCommand.java
