### PR TITLE
Add zk_peer_state translation

### DIFF
--- a/zk-collectd.py
+++ b/zk-collectd.py
@@ -101,6 +101,9 @@ class ZooKeeperServer(object):
                 key, value = self._parse_line(line)
                 if key == "zk_server_state":
                     result["zk_is_leader"] = int(value != "follower")
+                # any value of type string, other than zk_is_leader and zk_version, will be skipped
+                elif key != "zk_version" and isinstance(value, str):
+                    collectd.debug("zookeeper plugin: key: %s value: key: %s not supported" % (key, value))
                 else:
                     result[key] = value
             except ValueError:


### PR DESCRIPTION
Although this metric is not supported by the SA, but when it's dispatched from this plugin, it results of this error

```
ERRO[0014] Could not handle message from Python          error="parse error: expected number near offset 47 of 'leading - ...'" monitorID=1 monitorType=collectd/zookeeper runnerPID=10134 
```

In this PR, we make sure that only `zk_is_leader` and `zk_version` of string values will be translated, any other key with value type string will be logged and skipped

Signed-off-by: Dani Louca <dlouca@splunk.com>