### PR TITLE
prevent "Connection reset by peer" error on the server side

### DIFF
--- a/zk-collectd.py
+++ b/zk-collectd.py
@@ -63,9 +63,14 @@ class ZooKeeperServer(object):
             s.settimeout(self._timeout)
 
             s.connect(self._address)
-            s.send(cmd.encode("utf-8"))
+            s.sendall(cmd.encode("utf-8"))
+            s.shutdown(socket.SHUT_WR)
 
-            response = s.recv(2048)
+            while 1:
+                data = s.recv(2048)
+                if len(data) == 0:
+                    break
+                response += data
             s.close()
         except socket.timeout:
             log('Service not healthy: timed out calling "%s"' % cmd)


### PR DESCRIPTION
Some zookeeper servers, I could not reproduce it locally, log the below error when the current plugin sends `mntr`  
We have verified that `echo mntr | nc localhost 2181` does not result of an error.
In addition, the command output was getting truncated as it exceeded `2048`

This fix addresses the log error and the truncated output, it was validated against the repro server.

Signed-off-by: Dani Louca <dlouca@splunk.com>