### PR TITLE
Fixed zk_version splitting for complex build number

### DIFF
--- a/zk-collectd.py
+++ b/zk-collectd.py
@@ -145,7 +145,7 @@ def read_callback():
         for host in conf["hosts"]:
             zk = ZooKeeperServer(host, conf["port"])
             stats = zk.get_stats()
-            zk_version = stats["zk_version"].split(",")[0]
+            zk_version = stats["zk_version"].split(",")[0].replace(".", "_")
             del stats["zk_version"]
             for k, v in list(stats.items()):
                 try:


### PR DESCRIPTION
Fixed `zk_version` splitting for complex build number like `zookeeper-_zk_version_3.4.5-cdh5.14.4--1_` from Cloudera. After this commit we will have `zookeeper-_zk_version_3_4_5-cdh5_14_4--1_` without unnecessary nesting levels and as result we will have unified metric name `%hostname%.%zookeeper_version%.%metric_name%` in Graphite.